### PR TITLE
Add support for pop = "*" for quadrant gating methods

### DIFF
--- a/R/gating-methods.R
+++ b/R/gating-methods.R
@@ -385,14 +385,8 @@ roxygen_parameter <- function() {
     # For gate_quad methods, need to filter down to just the gates that were asked for
     if(names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
       pops <- gtPop@name
-      # keep all populations when pop = * and alias supplied
-      if(all(pops == "*")) {
-        if(length(popAlias) != 4) {
-          stop(
-            "'alias' must contain names for every quadrant when 'pop = *'!"
-          )
-        }
-      } else {
+      # keep all populations when pop = *
+      if(!all(pops == "*")) {
         pops <- gsub("([\\+-])([^/$])", "\\1&\\2", pops)
         pops <- strsplit(pops, "&")[[1]]
         pops <- strsplit(pops, "/")

--- a/R/gating-methods.R
+++ b/R/gating-methods.R
@@ -381,16 +381,25 @@ roxygen_parameter <- function() {
           popAlias <- NULL  
       }
     }
-
+    
     # For gate_quad methods, need to filter down to just the gates that were asked for
     if(names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
       pops <- gtPop@name
-      pops <- gsub("([\\+-])([^/$])", "\\1&\\2", pops)
-      pops <- strsplit(pops, "&")[[1]]
-      pops <- strsplit(pops, "/")
-      pops <- paste0(rep(pops[[1]], each=length(pops[[2]])), pops[[2]])
-      pops <- match(pops, c("-+", "++", "+-", "--"))
-      flist <- lapply(flist, function(sublist) filters(sublist[pops]))
+      # keep all populations when pop = * and alias supplied
+      if(all(pops == "*")) {
+        if(length(popAlias) != 4) {
+          stop(
+            "'alias' must contain names for every quadrant when 'pop = *'!"
+          )
+        }
+      } else {
+        pops <- gsub("([\\+-])([^/$])", "\\1&\\2", pops)
+        pops <- strsplit(pops, "&")[[1]]
+        pops <- strsplit(pops, "/")
+        pops <- paste0(rep(pops[[1]], each=length(pops[[2]])), pops[[2]])
+        pops <- match(pops, c("-+", "++", "+-", "--"))
+        flist <- lapply(flist, function(sublist) filters(sublist[pops]))
+      }
     }
     
     gs_node_id <- gs_pop_add(y, flist, parent = parent, name = popAlias, validityCheck = FALSE, negated = negated)


### PR DESCRIPTION
This PR addresses the issue raised in #241 regarding the use of `pop = "*"` for quadrant gating methods. Looking at the code base, `pop = "*"` is not currently supported for quadrant gating methods. When `pop = "*"` the user wants to keep all quadrant gates and population names can be supplied through `alias`. 

I initially added a length check on `alias` but removed it to allow `alias = "*"` as well, so that the default population names can be used for the quadrant gates if they are not manually supplied. 

Quadrant gates can now be manually labelled through `alias`:
```{r}
# manual alias
gs_add_gating_method(
  gs,
  alias = "A,B,C,D",
  pop = "*",
  parent = "root",
  dims = "CD4,CD8",
  gating_method = "gate_quad_sequential",
  gating_args = list(
    gFunc = "mindensity"
  )
)
# population names
gs_get_pop_paths(gs)
> "root" "/A" "/B" "/C" "/D"
```
![image](https://user-images.githubusercontent.com/125331387/227396583-0362ff58-33b4-4e0b-b513-1e4dae675126.png)

Or default names can be used with `alias = "*"`:
```{r}
# manual alias
gs_add_gating_method(
  gs,
  alias = "*",
  pop = "*",
  parent = "root",
  dims = "CD4,CD8",
  gating_method = "gate_quad_sequential",
  gating_args = list(
    gFunc = "mindensity"
  )
)
# population names
gs_get_pop_paths(gs)
> "root" "/Alexa Fluor 700-A-Alexa Fluor 488-A+" "/Alexa Fluor 700-A+Alexa Fluor 488-A+" 
 "/Alexa Fluor 700-A+Alexa Fluor 488-A-" "/Alexa Fluor 700-A-Alexa Fluor 488-A-" 
```
![image](https://user-images.githubusercontent.com/125331387/227397104-ab2a14cb-a970-4d79-9799-49c94dc39240.png)

