### PR TITLE
Handle multiple alias in GatingSet check.

### DIFF
--- a/R/preprocessing-method.R
+++ b/R/preprocessing-method.R
@@ -53,7 +53,7 @@ update_list <- function (x, val)
   popId <- gtPop@id
   
   gs_nodes <- basename(gs_pop_get_children(y[[1]], parent))
-  if (length(gs_nodes) == 0 || !popAlias %in% gs_nodes) {
+  if (length(gs_nodes) == 0 || !any(popAlias %in% gs_nodes)) {
     message("Preprocessing for '", popAlias, "'")
     
     parent_data <- gs_pop_get_data(y, parent)


### PR DESCRIPTION
@mikejiang, just making sure that this check (alias versus current descendant nodes in GatingSet) runs with multiple populations (e.g. quadrant gates). Currently, we get an error as it returns a logical with multiple values (one value per `popAlias`) which throws an error for latest version of R.