### PR TITLE
Evaluate minEvents gating argument for CytoExploreR.

### DIFF
--- a/R/wrapper-functions.R
+++ b/R/wrapper-functions.R
@@ -42,6 +42,9 @@
     minEvents <- openCyto.options[["gating"]][["minEvents"]]
     # Allow rowwise specification of minEvents
     row_minEvents <- gFunc_args[["openCyto.minEvents"]]
+    if(is.call(row_minEvents)) {
+      row_minEvents <- eval(row_minEvents)
+    }
     if(!is.null(row_minEvents)){
       minEvents <- row_minEvents
       gFunc_args[["openCyto.minEvents"]] <- NULL


### PR DESCRIPTION
@mikejiang, a recent change in the latest version of R is causing issues for CytoExploreR.

I've tracked down the issue as described in this [ticket](https://ozette.atlassian.net/browse/ODC-143).

Basically all gating arguments are passed in as `calls` which get automatically evaluated during this `do.call()` [chunk](https://github.com/RGLab/openCyto/blob/fe3c84c4e41074803c5ebb435af98f23f7324795/R/wrapper-functions.R#L94-L102) which invokes the gating function. The `minEvents` argument is dropped from this list and therefore remains a `call` when the event number check is performed.

To be safe I have wrapped the `call` evaluation in an if statement.

Adding @mikejiang for review as this fix is required on BioC for CytoExploreR to work - first reported [here](https://github.com/DillonHammill/CytoExploreR/issues/202).