### PR TITLE
ODC-184 support split and duplicated dims in gs_add_gating_method().

### DIFF
--- a/R/add_pop.R
+++ b/R/add_pop.R
@@ -77,6 +77,9 @@ gs_add_gating_method <- function(gs, alias = "*"
     preprocessing_args <- .argDeparser(preprocessing_args)      
   }
   
+  # format split dims & drop duplicated dims
+  dims <- paste(unique(dims), collapse = ",")
+  
   thisRow <- data.table(alias = alias
                         , pop = pop
                         , parent = parent


### PR DESCRIPTION
@amcdavid adding PR here to implement features or fixes required by CytoExploreR please see https://ozette.atlassian.net/jira/software/c/projects/ODC/issues/ODC-184

This PR just makes it easier for users to interact with the `gs_add_gating_method()` API which currently expects `dims` to be supplied in a concatenated comma-separated string (i.e. "FSC-A,SSC-A") rather than the conventional `c("FSC-A", "SSC-A")` - both inputs will be supported after this change.