### PR TITLE
ODC-185 bypass quadrant selection when pop = "*".

### DIFF
--- a/R/gating-methods.R
+++ b/R/gating-methods.R
@@ -382,7 +382,7 @@ roxygen_parameter <- function() {
     }
 
     # For gate_quad methods, need to filter down to just the gates that were asked for if pop != "*"
-    if(!all(popName %in% "*") & names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
+    if(!all(popName %in% "*") && names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
       pops <- gtPop@name
       pops <- gsub("([\\+-])([^/$])", "\\1&\\2", pops)
       pops <- strsplit(pops, "&")[[1]]

--- a/R/gating-methods.R
+++ b/R/gating-methods.R
@@ -381,8 +381,8 @@ roxygen_parameter <- function() {
       }
     }
 
-    # For gate_quad methods, need to filter down to just the gates that were asked for
-    if(names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
+    # For gate_quad methods, need to filter down to just the gates that were asked for if pop != "*"
+    if(!all(popName %in% "*") & names(x) %in% c("quadGate.seq", "gate_quad_sequential", "quadGate.tmix", "gate_quad_tmix")){
       pops <- gtPop@name
       pops <- gsub("([\\+-])([^/$])", "\\1&\\2", pops)
       pops <- strsplit(pops, "&")[[1]]


### PR DESCRIPTION
Looks like I missed an additional quadrant gate check when I added support for manual quadrant names and pop = "*".

See https://github.com/RGLab/openCyto/pull/245 and https://github.com/RGLab/openCyto/issues/254.