### PR TITLE
ODC-186 remove duplicated default preprocessing method.

### DIFF
--- a/R/pluginFramework.R
+++ b/R/pluginFramework.R
@@ -10,7 +10,7 @@ NULL
                  , "mindensity2", "gate_mindensity2", "cytokine", "flowClust.1d", "gate_flowclust_1d", "boundary","singletGate"
                   , "quadGate.tmix", "gate_quad_tmix", "quadGate.seq", "gate_quad_sequential"
                  )
-.DEFAULT_PP <- c("prior_flowClust", "prior_flowClust", "warpSet", "standardize_flowset")
+.DEFAULT_PP <- c("prior_flowClust", "warpSet", "standardize_flowset")
 #'Print a list of the registered gating methods
 #'@name gt_list_methods
 #'@aliases listgtMethods


### PR DESCRIPTION
Tidying up lingering issues. This minor change never got merged to the `devel` branch: https://github.com/RGLab/openCyto/issues/230

This PR remove the duplicated default preprocessing method.