### PR TITLE
ODC-188 drop legacy GatingSetList from openCyto test suite.

### DIFF
--- a/R/gating-methods.R
+++ b/R/gating-methods.R
@@ -583,7 +583,12 @@ gt_gating.dummyMethod <- function(x, y, ...) {
       # standardize the names for the gate parameters and dims
       gate_params <- unlist(lapply(glist, function(g) {
         cur_param <- parameters(g)
-        getChannelMarker(fr, cur_param)["name"]
+        sapply(
+          cur_param,
+          function(param) {
+            getChannelMarker(fr, param)["name"]
+          }
+        )
       }))
       negated_2d_gate <- FALSE
       if(length(glist)==1){

--- a/tests/testthat/test-add-remove-pop.R
+++ b/tests/testthat/test-add-remove-pop.R
@@ -28,9 +28,9 @@ test_that("gs_remove_gating_method testing", {
   gs_remove_gating_method(gs)
   gs_remove_gating_method(gs)
 
-  # Just to prevent GatingSetList constructor from protesting overlapping samples
+  # Just to prevent merge_list_to_gs constructor from protesting overlapping samples
   sampleNames(gs2) <- "CytoTrol_Cytotrol_2.fcs"
-  gslist <- GatingSetList(list(gs1, gs2))
+  gslist <- merge_list_to_gs(list(gs1, gs2))
 
   expect_equal(gs_get_pop_paths(gslist[[1]]), snapshot_pre)
   gs_add_gating_method(gslist, alias = "*", pop = "+/-", parent = "/not debris", dims = "CD4", gating_method = "mindensity")


### PR DESCRIPTION
@amcdavid this is a very minor change to remove the legacy `GatingSetList` constructor from the openCyto test suite.